### PR TITLE
Refactor and improve hypw.py main script

### DIFF
--- a/hypw/hypw.py
+++ b/hypw/hypw.py
@@ -6,6 +6,7 @@ import hypw.design as dsn
 import hypw.color as clr
 import hypw.setting as setting
 import PIL as pil  # type: ignore
+import argparse
 
 from hypw.typing import Transformation, Order
 
@@ -28,21 +29,32 @@ def filename(o: Order, form: int, pat: int):
     a = str(int(p)) if p is not np.inf else 'i'
     b = str(int(q)) if q is not np.inf else 'i'
     c = str(int(r)) if r is not np.inf else 'i'
-    return '%s%s%s-%d-%03d.png' % (a, b, c, i, j)
+    return '%s%s%s-%d-%03d.png' % (a, b, c, form, pat)
 
 
 if __name__ == '__main__':
     import time
 
+    parser = argparse.ArgumentParser(description="Generate hyperbolic tilings.")
+    parser.add_argument('--p', type=int, default=2, help='Parameter p for the Schwarz triangle (default: 2)')
+    parser.add_argument('--q', type=int, default=3, help='Parameter q for the Schwarz triangle (default: 3)')
+    parser.add_argument('--r', type=int, default=7, help='Parameter r for the Schwarz triangle (default: 7)')
+    args = parser.parse_args()
+
     start = time.time()
 
-    p, q, r = 2, 3, 7
+    p, q, r = args.p, args.q, args.r
     mirror = mir.init((p, q, r))
     print(mirror)
+    # Each tuple in 'forms' likely represents a specific configuration for the tiling pattern.
+    # These could be defined as named constants if their specific meanings are known,
+    # e.g., FORM_A = (0, 0, 1), FORM_B = (0, 1, 0), etc.
     forms = [(0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)]
     for i in range(len(forms)):
+        # Iterate through a set of 128 pattern variations
         for j in range(128):
             card, img = draw(mirror, forms[i], j)
+            # Save the image only if it has a minimum level of complexity (more than 2 distinct regions/colors)
             if card > 2:
                 pil.Image.fromarray(img).save(filename((p, q, r), i, i))
 


### PR DESCRIPTION
This commit introduces several improvements to the main script `hypw/hypw.py`:

1.  **Fix `filename` function bug:** The `filename` function now correctly uses its `form` and `pat` parameters for generating image filenames, instead of relying on global variables `i` and `j`.

2.  **Configurable (p, q, r) parameters:** The Schwarz triangle parameters (p, q, r) are now configurable via command-line arguments:
    *   `--p` (default: 2)
    *   `--q` (default: 3)
    *   `--r` (default: 7)
    This allows for greater flexibility in generating different types of hyperbolic tilings without modifying the source code.

3.  **Improved code clarity with comments:**
    *   Added a comment to explain that images are saved only if `card > 2` (i.e., if they have more than two distinct regions/colors), providing context for this condition.
    *   Added a comment to clarify that the loop `for j in range(128):` iterates through different pattern variations.
    *   Added a comment to the `forms` list, explaining its structure and suggesting that named constants could be used if the specific meanings of the form tuples were known.

These changes enhance the script's usability, maintainability, and readability.