### PR TITLE
Configure project for PyPI publishing

### DIFF
--- a/hypw/hypw.py
+++ b/hypw/hypw.py
@@ -32,7 +32,7 @@ def filename(o: Order, form: int, pat: int):
     return '%s%s%s-%d-%03d.png' % (a, b, c, form, pat)
 
 
-if __name__ == '__main__':
+def main_cli():
     import time
 
     parser = argparse.ArgumentParser(description="Generate hyperbolic tilings.")
@@ -59,3 +59,6 @@ if __name__ == '__main__':
                 pil.Image.fromarray(img).save(filename((p, q, r), i, i))
 
     print("time:", time.time() - start)
+
+if __name__ == '__main__':
+    main_cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+backend-path = "."
+
 [project]
 name = "hypwyth"
 version = "0.0.1"
@@ -15,7 +20,18 @@ maintainers = [
 ]
 classifiers = [
   "Development Status :: 4 - Beta",
-  "Programming Language :: Python"
+  "Intended Audience :: Science/Research",
+  "Intended Audience :: Education",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Scientific/Engineering :: Mathematics",
+  "Topic :: Scientific/Engineering :: Visualization"
 ]
 
 dependencies = [
@@ -34,7 +50,7 @@ documentation = "https://github.com/mountain/hyperbolic-wythoff"
 repository = "https://github.com/mountain/hyperbolic-wythoff"
 
 [project.scripts]
-hypw = "hypw:hypw"
+hypw = "hypw.hypw:main_cli"
 
 [tool.mypy]
 python_version = "3.9"


### PR DESCRIPTION
This commit prepares the project for publishing to PyPI.

Changes include:

1.  **Refactored `hypw/hypw.py`:**
    *   Introduced a `main_cli()` function to encapsulate the script's main logic.
    *   The `if __name__ == '__main__':` block now calls `main_cli()`.
    This change allows the script to be called as a console script entry point.

2.  **Updated `pyproject.toml`:**
    *   Added a `[build-system]` table specifying `setuptools` and `wheel` as requirements.
    *   Expanded the `classifiers` list to include more detailed information about the package (license, Python versions, audience, topic).
    *   Corrected the `[project.scripts]` entry point to `hypw = "hypw.hypw:main_cli"` to align with the refactoring in `hypw/hypw.py`.

These modifications ensure that the project can be built into a distributable package (sdist and wheel) and is correctly configured for uploading to the Python Package Index (PyPI).