### PR TITLE
Feat: Implement selectable tiling styles and enhance configurability

### DIFF
--- a/hypw/design.py
+++ b/hypw/design.py
@@ -7,6 +7,8 @@ from hypw.setting import width, linewidth
 
 
 def checkboard(ps, mirrors):
+    # Implements the "checkboard" style of tiling, creating a binary pattern
+    # based on reflections and region counts.
     u, v, w = mirrors
     rs = np.zeros([width, width, 1], dtype=int)
     ts = np.zeros([width, width, 1], dtype=bool)
@@ -23,6 +25,12 @@ def checkboard(ps, mirrors):
 
 
 def edged(ps, mirrors):
+    # Implements the "edged" style of tiling.
+    # This style highlights the edges of the fundamental regions.
+    # It is achieved by calling the 'patterned' function with a
+    # specific predefined form=(1,0,1) and pattern ID=16.
+    #
+    # The following commented-out code represents a previous, direct implementation attempt.
     #u, v, w = mirrors
     #rs = np.zeros([width, width, 1], dtype=int)
     #ts = np.zeros([width, width, 1], dtype=bool)
@@ -38,6 +46,9 @@ def edged(ps, mirrors):
 
 
 def patterned(ps, mirrors, form, pat):
+    # Implements a versatile, complex styling method based on 'form' and 'pat' (pattern ID) parameters.
+    # 'form' defines critical planes, and 'pat' (a bitmask) controls various aspects
+    # like coloring specific regions or highlighting different types of edges.
     u, v, w = mirrors
     a, b, c = mir.critical_plane(mirrors, form)
 

--- a/hypw/hypw.py
+++ b/hypw/hypw.py
@@ -15,21 +15,64 @@ coord = np.linspace(-1, 1, num=setting.width, dtype=np.complex128)
 data = np.array([[x, y] for y in coord for x in coord]).reshape(setting.width, setting.width, 2)
 
 
-def draw(mirror: Transformation, form, pat):
+# Ensure dsn is imported as: import hypw.design as dsn
+# Ensure geom is imported as: import hypw.geometry as geom
+# Ensure clr is imported as: import hypw.color as clr
+# Ensure np is imported as: import numpy as np
+# Ensure Transformation is available from hypw.typing
+
+# Global 'data' should already be defined:
+# coord = np.linspace(-1, 1, num=setting.width, dtype=np.complex128)
+# data = np.array([[x, y] for y in coord for x in coord]).reshape(setting.width, setting.width, 2)
+
+def generate_tiling_data(mirror: Transformation, style: str, form_tuple=None, pat_id=None):
     disk = geom.radius(data) < 1
-    ps = geom.pdm2hbm(data)
-    ts = (1 + dsn.patterned(ps, mirror, form, pat)) * disk
-    max = np.max(ts)
+    ps = geom.pdm2hbm(data)  # Poincare disk model to half-plane model
+
+    styled_ts = None
+    if style == "checkboard":
+        styled_ts = dsn.checkboard(ps, mirror)
+    elif style == "edged":
+        styled_ts = dsn.edged(ps, mirror) # dsn.edged calls dsn.patterned with specific params
+    elif style == "patterned":
+        if form_tuple is None or pat_id is None:
+            raise ValueError("form_tuple and pat_id must be provided for 'patterned' style.")
+        styled_ts = dsn.patterned(ps, mirror, form_tuple, pat_id)
+    else:
+        raise ValueError(f"Unknown style: {style}")
+
+    # Apply disk and offset, ensuring styled_ts is not None (already handled by ValueError)
+    ts = (1 + styled_ts) * disk
+
+    max_val = np.max(ts)
     crd = len(np.unique(ts))
-    return crd, clr.colorbar(max)[ts][:, :, 0, :]
+
+    # Ensure colorbar indexing is robust
+    # The design functions return boolean arrays for ts.
+    # (1 + styled_ts) makes it 0 or 1 for False/True, then disk makes parts outside 0.
+    # So ts elements are likely integers (0, 1, possibly more if styled_ts was not just 0/1).
+    # Using .astype(int) is a good safeguard for indexing.
+    return crd, clr.colorbar(max_val)[ts.astype(int)][:, :, 0, :]
 
 
-def filename(o: Order, form: int, pat: int):
-    p, q, r = o
+def filename(order: Order, style: str, form_idx: int = None, pat_id: int = None) -> str:
+    p, q, r = order
     a = str(int(p)) if p is not np.inf else 'i'
     b = str(int(q)) if q is not np.inf else 'i'
     c = str(int(r)) if r is not np.inf else 'i'
-    return '%s%s%s-%d-%03d.png' % (a, b, c, form, pat)
+
+    base = f"{a}{b}{c}"
+    if style == "checkboard":
+        return f"{base}-checkboard.png"
+    elif style == "edged":
+        return f"{base}-edged.png"
+    elif style == "patterned":
+        if form_idx is None or pat_id is None:
+            # This case should ideally not be reached if main_cli calls it correctly
+            raise ValueError("form_idx and pat_id are required for patterned style filenames.")
+        return f"{base}-patterned-form{form_idx}-pat{pat_id:03d}.png" # Ensure pat_id is zero-padded
+    else:
+        raise ValueError(f"Unknown style for filename: {style}")
 
 
 def main_cli():
@@ -39,6 +82,28 @@ def main_cli():
     parser.add_argument('--p', type=int, default=2, help='Parameter p for the Schwarz triangle (default: 2)')
     parser.add_argument('--q', type=int, default=3, help='Parameter q for the Schwarz triangle (default: 3)')
     parser.add_argument('--r', type=int, default=7, help='Parameter r for the Schwarz triangle (default: 7)')
+
+    # New arguments
+    parser.add_argument(
+        '--style',
+        type=str,
+        choices=["checkboard", "edged", "patterned"],
+        default="patterned",
+        help="The style of tiling to generate. (default: patterned)"
+    )
+    parser.add_argument(
+        '--form_idx',
+        type=int,
+        default=None, # Explicitly None if not provided
+        help="Index of the form from the predefined list (for 'patterned' style). If specified with --pattern_id, generates a single image."
+    )
+    parser.add_argument(
+        '--pattern_id',
+        type=int,
+        default=None, # Explicitly None if not provided
+        help="Pattern ID (e.g., 0-127) (for 'patterned' style). If specified with --form_idx, generates a single image."
+    )
+
     args = parser.parse_args()
 
     start = time.time()
@@ -49,14 +114,43 @@ def main_cli():
     # Each tuple in 'forms' likely represents a specific configuration for the tiling pattern.
     # These could be defined as named constants if their specific meanings are known,
     # e.g., FORM_A = (0, 0, 1), FORM_B = (0, 1, 0), etc.
-    forms = [(0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)]
-    for i in range(len(forms)):
-        # Iterate through a set of 128 pattern variations
-        for j in range(128):
-            card, img = draw(mirror, forms[i], j)
-            # Save the image only if it has a minimum level of complexity (more than 2 distinct regions/colors)
-            if card > 2:
-                pil.Image.fromarray(img).save(filename((p, q, r), i, i))
+    forms = [(0, 0, 1), (0, 1, 0), (0, 1, 1), (1, 0, 0), (1, 0, 1), (1, 1, 0), (1, 1, 1)] # Ensure this is defined
+
+    if args.style == "checkboard":
+        card, img = generate_tiling_data(mirror, style="checkboard")
+        if card > 2: # or some relevant condition
+            output_filename = filename((args.p, args.q, args.r), style="checkboard")
+            pil.Image.fromarray(img).save(output_filename)
+            print(f"Saved: {output_filename}")
+
+    elif args.style == "edged":
+        card, img = generate_tiling_data(mirror, style="edged")
+        if card > 2: # or some relevant condition
+            output_filename = filename((args.p, args.q, args.r), style="edged")
+            pil.Image.fromarray(img).save(output_filename)
+            print(f"Saved: {output_filename}")
+
+    elif args.style == "patterned":
+        if args.form_idx is not None and args.pattern_id is not None:
+            if 0 <= args.form_idx < len(forms):
+                selected_form_tuple = forms[args.form_idx] # Get the form tuple
+                card, img = generate_tiling_data(mirror, style="patterned", form_tuple=selected_form_tuple, pat_id=args.pattern_id)
+                if card > 2: # or some relevant condition
+                    output_filename = filename((args.p, args.q, args.r), style="patterned", form_idx=args.form_idx, pat_id=args.pattern_id)
+                    pil.Image.fromarray(img).save(output_filename)
+                    print(f"Saved: {output_filename}")
+            else:
+                # Error message for out of range form_idx remains as print.
+                print(f"ERROR: --form_idx {args.form_idx} is out of range for the predefined forms list (0-{len(forms)-1}).")
+        else: # Loop for all forms and patterns
+            for i_loop_idx in range(len(forms)):
+                current_form_tuple = forms[i_loop_idx]
+                for j_loop_idx in range(128): # Iterate through pattern IDs 0-127
+                    card, img = generate_tiling_data(mirror, style="patterned", form_tuple=current_form_tuple, pat_id=j_loop_idx)
+                    if card > 2: # Use the existing condition for saving
+                        output_filename = filename((args.p, args.q, args.r), style="patterned", form_idx=i_loop_idx, pat_id=j_loop_idx)
+                        pil.Image.fromarray(img).save(output_filename)
+                        # print(f"Saved: {output_filename}") # Optional, could be too verbose in a loop
 
     print("time:", time.time() - start)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
-backend-path = "."
 
 [project]
 name = "hypwyth"

--- a/tests/test_hypw.py
+++ b/tests/test_hypw.py
@@ -1,0 +1,30 @@
+# tests/test_hypw.py
+import numpy as np
+import pytest
+from hypw.hypw import filename
+
+# Test cases for the filename function
+def test_filename_checkboard():
+    assert filename((2, 3, 7), style="checkboard") == "237-checkboard.png"
+    assert filename((2, 3, np.inf), style="checkboard") == "23i-checkboard.png"
+
+def test_filename_edged():
+    assert filename((4, 5, 6), style="edged") == "456-edged.png"
+    assert filename((np.inf, 5, 6), style="edged") == "i56-edged.png"
+
+def test_filename_patterned():
+    assert filename((2, 3, 7), style="patterned", form_idx=0, pat_id=5) == "237-patterned-form0-pat005.png"
+    assert filename((2, 3, 7), style="patterned", form_idx=1, pat_id=127) == "237-patterned-form1-pat127.png"
+    assert filename((np.inf, 3, np.inf), style="patterned", form_idx=2, pat_id=0) == "i3i-patterned-form2-pat000.png"
+
+def test_filename_invalid_style():
+    with pytest.raises(ValueError, match="Unknown style for filename: invalid"):
+        filename((2,3,7), style="invalid")
+
+def test_filename_patterned_missing_params():
+    with pytest.raises(ValueError, match="form_idx and pat_id are required for patterned style filenames."):
+        filename((2,3,7), style="patterned", form_idx=0) # Missing pat_id
+    with pytest.raises(ValueError, match="form_idx and pat_id are required for patterned style filenames."):
+        filename((2,3,7), style="patterned", pat_id=0) # Missing form_idx
+    with pytest.raises(ValueError, match="form_idx and pat_id are required for patterned style filenames."):
+        filename((2,3,7), style="patterned") # Missing both


### PR DESCRIPTION
This commit introduces a major feature allowing you to select different tiling styles ("checkboard", "edged", "patterned") via a new `--style` command-line argument. It also enhances configurability for the "patterned" style and improves the project's structure and testability.

Key changes:

1.  **Style Selection (`hypw/hypw.py`):**
    *   Added `--style` command-line argument with choices "checkboard",
        "edged", and "patterned" (default).
    *   Added optional `--form_idx` and `--pattern_id` arguments to allow
        generation of specific patterns when `--style=patterned`. If not
        provided, the script loops through all predefined forms and patterns
        as before for the "patterned" style.
    *   The main script logic in `main_cli` now routes to different image
        generation paths based on the selected style.

2.  **Refactored Drawing Logic (`hypw/hypw.py`):**
    *   The old `draw` function was replaced by `generate_tiling_data`,
        which now takes `style`, `form_tuple`, and `pat_id` as arguments.
    *   `generate_tiling_data` calls the appropriate function from the
        `hypw.design` module (`checkboard`, `edged`, or `patterned`) based
        on the selected style.

3.  **Updated Filename Generation (`hypw/hypw.py`):**
    *   The `filename` function was updated to produce style-aware names:
        *   `{pqr}-checkboard.png`
        *   `{pqr}-edged.png`
        *   `{pqr}-patterned-form{form_idx}-pat{pat_id:03d}.png`
    *   This function is now used for all saved images.

4.  **Design Module Clarity (`hypw/design.py`):**
    *   Added comments to `checkboard`, `edged`, and `patterned` functions
        to clarify their purpose and implementation, especially noting that
        `edged` is a specific configuration of `patterned`.

5.  **Unit Tests (`tests/test_hypw.py`):**
    *   Added a new test file `tests/test_hypw.py`.
    *   Implemented comprehensive unit tests for the `filename` function,
        covering all styles, parameter variations (including np.inf), and
        error conditions. All tests pass.

6.  **Build Configuration (`pyproject.toml`):**
    *   Removed `backend-path = "."` from the `[build-system]` table. This
        fixes an issue that prevented editable installs with test
        dependencies (`pip install -e .[test]`).

These changes significantly enhance the flexibility and usability of the hyperbolic tiling generator, provide a more robust development setup, and lay the groundwork for further extensions.